### PR TITLE
Tapioka

### DIFF
--- a/app/src/main/java/mi191324/example/stareffort/FriendrecordActivity.kt
+++ b/app/src/main/java/mi191324/example/stareffort/FriendrecordActivity.kt
@@ -1,0 +1,18 @@
+package mi191324.example.stareffort
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.Button
+
+class FriendrecordActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_friendrecord)
+        val btnBack :Button = findViewById(R.id.btnBack)
+
+        //３）戻るボタン（アクティビティの終了）
+        btnBack.setOnClickListener {
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/mi191324/example/stareffort/MainActivity.kt
+++ b/app/src/main/java/mi191324/example/stareffort/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Button
 
+
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/mi191324/example/stareffort/MainActivity.kt
+++ b/app/src/main/java/mi191324/example/stareffort/MainActivity.kt
@@ -1,11 +1,39 @@
 package mi191324.example.stareffort
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.Button
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        //１）Viewの取得
+        val myrecord: Button = findViewById(R.id.myrecord)
+
+        //２）ボタンを押したら次の画面へ
+        myrecord.setOnClickListener {
+            val intent = Intent(this, MyrecordActivity::class.java)
+            startActivity(intent)
+
+            val friendrecord: Button = findViewById(R.id.friendsrecord)
+
+            //3）ボタンを押したら次の画面へ
+            friendrecord.setOnClickListener {
+                val intent = Intent(this, FriendrecordActivity::class.java)
+                startActivity(intent)
+
+                val setting: Button = findViewById(R.id.setting)
+
+                //4）ボタンを押したら次の画面へ
+                setting.setOnClickListener {
+                    val intent = Intent(this, SettingActivity::class.java)
+                    startActivity(intent)
+
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/mi191324/example/stareffort/MyrecordActivity.kt
+++ b/app/src/main/java/mi191324/example/stareffort/MyrecordActivity.kt
@@ -1,0 +1,18 @@
+package mi191324.example.stareffort
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.Button
+
+class MyrecordActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_myrecord)
+        val btnBack :Button = findViewById(R.id.btnBack)
+
+        //３）戻るボタン（アクティビティの終了）
+        btnBack.setOnClickListener {
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/mi191324/example/stareffort/SettingActivity.kt
+++ b/app/src/main/java/mi191324/example/stareffort/SettingActivity.kt
@@ -1,0 +1,35 @@
+package mi191324.example.stareffort
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.Button
+import android.widget.ArrayAdapter
+import kotlinx.android.synthetic.main.activity_setting.*
+
+class SettingActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_setting)
+
+        // Adapterに渡す配列を作成
+        val data = arrayOf("プロフィール", "通知", "友達追加", "他アプリロック")
+
+        // adapterを作成
+        val adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_list_item_1,
+            data
+        )
+
+        // adapterをlistViewに紐付け
+        listView.adapter = adapter
+
+
+val btnBack: Button = findViewById(R.id.btnBack)
+
+            //戻るボタン（アクティビティの終了）
+            btnBack.setOnClickListener {
+                finish()
+            }
+        }
+    }

--- a/app/src/main/res/layout/activity_friendrecord.xml
+++ b/app/src/main/res/layout/activity_friendrecord.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FriendrecordActivity">
+
+    <Button
+        android:id="@+id/btnBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="戻る"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.043" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
+    <Button
+        android:id="@+id/myrecord"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:text="自分"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.145"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.500" />
 
+    <Button
+        android:id="@+id/friendsrecord"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="友達"
+        tools:layout_editor_absoluteX="159dp"
+        tools:layout_editor_absoluteY="342dp"
+        tools:ignore="MissingConstraints" />
+
+    <Button
+        android:id="@+id/setting"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="設定"
+        tools:layout_editor_absoluteX="265dp"
+        tools:layout_editor_absoluteY="342dp"
+        tools:ignore="MissingConstraints" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_myrecord.xml
+++ b/app/src/main/res/layout/activity_myrecord.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MyrecordActivity">
+
+    <Button
+        android:id="@+id/btnBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="戻る"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.043" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SettingActivity">
+
+    <ListView
+        android:id="@+id/listView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btnBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="戻る"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.043" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
intentを使ってメイン画面から3つ別々の画面に遷移するようにした
メイン画面に自分ボタン、友達ボタン、設定ボタンを配置
自分ボタンをタップしたら自身の学習時間確認画面に遷移
そこで戻るボタンがタップされたらメイン画面に戻る
友達ボタンがタップされたらフレンドの学習時間確認画面に遷移
戻るボタンがタップされたらメイン画面に戻る
メイン画面で設定ボタンがタップされたら設定画面に遷移
設定画面ではListViewでプロフィール、通知、友達追加、他アプリロックの4つをリスト表示してます
一通りのおおまかな流れをとりあえず終えた感じです
グラフとか設定画面のとこのリストの要素をタップした後の処理とかはかけていません